### PR TITLE
fix: preserve Windows workspace sessions

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Run Extension",
+      "type": "extensionHost",
+      "request": "launch",
+      "args": [
+        "--extensionDevelopmentPath=${workspaceFolder}"
+      ],
+      "outFiles": [
+        "${workspaceFolder}/out/**/*.js"
+      ],
+      "preLaunchTask": "npm: compile"
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,12 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "type": "npm",
+      "script": "copy-templates",
+      "group": "build",
+      "label": "npm: copy-templates",
+      "detail": "Copy HTML templates to out/"
+    }
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
-  "name": "opencode-chat",
+  "name": "opencode-chat-unofficial",
   "version": "2.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "opencode-chat",
+      "name": "opencode-chat-unofficial",
       "version": "2.9.0",
+      "license": "MIT",
       "devDependencies": {
         "@types/node": "^18.0.0",
         "@types/vscode": "^1.80.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "Other"
   ],
   "icon": "icon.png",
-  "activationEvents": [],
+  "activationEvents": [
+    "onStartupFinished"
+  ],
   "main": "./out/main.js",
   "contributes": {
     "commands": [
@@ -79,10 +81,10 @@
       "properties": {
         "opencode.port": {
           "type": "number",
-          "default": 0,
+          "default": 4096,
           "minimum": 0,
           "maximum": 65535,
-          "description": "Fixed port for the opencode server. Set to 0 (default) to use a random port. Note: changing the port resets preferences stored in the webview (e.g. theme) since they are tied to the origin."
+          "description": "Fixed port for the opencode server. Set to 0 to use a random port. Note: changing the port resets preferences stored in the webview (e.g. theme) since they are tied to the origin."
         },
         "opencode.exposeToNetwork": {
           "type": "boolean",
@@ -93,7 +95,7 @@
     }
   },
   "scripts": {
-    "copy-templates": "mkdir -p out/webview/templates && cp src/webview/templates/*.html out/webview/templates/",
+    "copy-templates": "node scripts/copy-templates.js",
     "compile": "tsc -p ./ && npm run copy-templates",
     "publish": "npm run compile && vsce publish && ovsx publish",
     "watch": "npm run copy-templates && tsc -w -p ./"

--- a/scripts/copy-templates.js
+++ b/scripts/copy-templates.js
@@ -1,0 +1,12 @@
+const fs = require("fs");
+const path = require("path");
+
+const root = path.resolve(__dirname, "..");
+const srcDir = path.join(root, "src", "webview", "templates");
+const outDir = path.join(root, "out", "webview", "templates");
+
+fs.mkdirSync(outDir, { recursive: true });
+
+for (const file of fs.readdirSync(srcDir)) {
+  fs.copyFileSync(path.join(srcDir, file), path.join(outDir, file));
+}

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,0 +1,21 @@
+import * as vscode from "vscode";
+
+let _channel: vscode.OutputChannel | undefined;
+
+export function getLogger(): vscode.OutputChannel {
+  if (!_channel) {
+    _channel = vscode.window.createOutputChannel("opencode", { log: true });
+  }
+  return _channel;
+}
+
+export function log(message: string): void {
+  const ts = new Date().toISOString().split("T")[1].replace("Z", "");
+  getLogger().appendLine(`[${ts}] ${message}`);
+}
+
+export function logError(message: string, err?: unknown): void {
+  const detail = err instanceof Error ? err.message : String(err ?? "");
+  const ts = new Date().toISOString().split("T")[1].replace("Z", "");
+  getLogger().appendLine(`[${ts}] ERROR: ${message}${detail ? " — " + detail : ""}`);
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,173 +1,166 @@
+import * as path from "path";
 import * as vscode from "vscode";
-import { OpencodeViewProvider } from "./webview/OpencodeViewProvider";
 import { ServerManager } from "./server/ServerManager";
+import { OpencodeViewProvider } from "./webview/OpencodeViewProvider";
+import { log } from "./logger";
 
+type ServerConfig = {
+  port: number;
+  proxyPort: number;
+  exposeToNetwork: boolean;
+  fixedPort: boolean;
+};
+
+let provider: OpencodeViewProvider | undefined;
 let serverManager: ServerManager | undefined;
+let starting = false;
 
 const SIDEBAR_CMDS = {
   primary: "workbench.action.toggleSidebarVisibility",
   auxiliary: "workbench.action.toggleAuxiliaryBar",
 } as const;
 
-export function activate(context: vscode.ExtensionContext) {
+function randomPort(): number {
+  return Math.floor(Math.random() * (65535 - 16384 + 1)) + 16384;
+}
+
+function workspacePath(): string | undefined {
+  const cwd = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+  return cwd ? path.normalize(cwd) : undefined;
+}
+
+function serverConfig(context: vscode.ExtensionContext): ServerConfig {
   const config = vscode.workspace.getConfiguration("opencode");
-
-  // If the user specified a port in settings, use it. Otherwise reuse the
-  // port from the last session so the iframe origin stays the same across
-  // restarts, preserving localStorage (theme, settings, etc.).
-  // Use globalState so every workspace shares the same origin and settings.
-  const userPort = config.get<number>("port", 0);
-  const storedPort = context.globalState.get<number>("opencode.serverPort");
-  const port =
-    userPort > 0
-      ? userPort
-      : (storedPort ?? Math.floor(Math.random() * (65535 - 16384 + 1)) + 16384);
-
-  const storedProxyPort =
-    context.globalState.get<number>("opencode.proxyPort");
-  const proxyPort =
-    storedProxyPort ?? Math.floor(Math.random() * (65535 - 16384 + 1)) + 16384;
-
+  const configuredPort = config.get<number>("port", 4096);
+  const fixedPort = configuredPort > 0;
+  const port = fixedPort ? configuredPort : randomPort();
+  const proxyPort = context.globalState.get<number>("opencode.proxyPort") ?? randomPort();
   const exposeToNetwork = config.get<boolean>("exposeToNetwork", false);
 
-  // Register the webview panel provider
-  const provider = new OpencodeViewProvider(context.extensionUri);
-  context.subscriptions.push(
-    vscode.window.registerWebviewViewProvider("opencode.chatView", provider, {
-      webviewOptions: { retainContextWhenHidden: true },
-    }),
-  );
+  log(`Config: port=${port}, proxyPort=${proxyPort}, exposeToNetwork=${exposeToNetwork}`);
+  return { port, proxyPort, exposeToNetwork, fixedPort };
+}
 
-  // Start the opencode server
-  serverManager = new ServerManager();
-  serverManager.start(provider, context, port, proxyPort, exposeToNetwork);
-
-  // Register the opencode.addToChat command
-  context.subscriptions.push(
-    vscode.commands.registerCommand(
-      "opencode.addToChat",
-      (uri?: vscode.Uri) => {
-        const fileUri = uri || vscode.window.activeTextEditor?.document.uri;
-        if (fileUri) {
-          const relativePath = vscode.workspace.asRelativePath(fileUri);
-          provider.addToChat(relativePath);
-        }
-      },
-    ),
-  );
-
-  // Register the opencode.addSelectionToChat command
-  context.subscriptions.push(
-    vscode.commands.registerCommand("opencode.addSelectionToChat", () => {
-      const editor = vscode.window.activeTextEditor;
-      if (!editor) return;
-
-      const sel = editor.selection;
-      const relativePath = vscode.workspace.asRelativePath(editor.document.uri);
-
-      let ref: string;
-      if (sel.isEmpty) {
-        // Cursor only — just line number
-        ref = `${relativePath}:${sel.start.line + 1}`;
-      } else if (sel.start.line === sel.end.line) {
-        // Single line selection — file:line:startCol-endCol
-        ref = `${relativePath}:${sel.start.line + 1}:${sel.start.character + 1}-${sel.end.character + 1}`;
-      } else {
-        // Multi-line selection — file:startLine:startCol-endLine:endCol
-        ref = `${relativePath}:${sel.start.line + 1}:${sel.start.character + 1}-${sel.end.line + 1}:${sel.end.character + 1}`;
-      }
-
-      provider.addToChat(ref);
-    }),
-  );
-
-  // Restore cached sidebar type from global state
-  const cachedSidebarType = context.globalState.get<"primary" | "auxiliary">(
-    "opencode.sidebarType",
-  );
-  if (cachedSidebarType) {
-    provider.sidebarType = cachedSidebarType;
+async function startServer(context: vscode.ExtensionContext): Promise<void> {
+  if (starting) {
+    log("startServer: already starting");
+    return;
   }
 
-  // Register the toggle command for showing/hiding the sidebar
+  const cwd = workspacePath();
+  if (!cwd) {
+    log("No workspace folder");
+    provider?.setLoading();
+    return;
+  }
+
+  starting = true;
+  try {
+    serverManager?.dispose();
+    serverManager = new ServerManager();
+
+    const config = serverConfig(context);
+    log(`Starting OpenCode for workspace: ${cwd}`);
+    await serverManager.start({
+      provider: provider!,
+      context,
+      cwd,
+      ...config,
+    });
+  } finally {
+    starting = false;
+  }
+}
+
+function selectionReference(editor: vscode.TextEditor): string {
+  const relativePath = vscode.workspace.asRelativePath(editor.document.uri);
+  const sel = editor.selection;
+
+  if (sel.isEmpty) return `${relativePath}:${sel.start.line + 1}`;
+  if (sel.start.line === sel.end.line) {
+    return `${relativePath}:${sel.start.line + 1}:${sel.start.character + 1}-${sel.end.character + 1}`;
+  }
+  return `${relativePath}:${sel.start.line + 1}:${sel.start.character + 1}-${sel.end.line + 1}:${sel.end.character + 1}`;
+}
+
+function registerCommands(context: vscode.ExtensionContext): void {
   context.subscriptions.push(
+    vscode.commands.registerCommand("opencode.addToChat", (uri?: vscode.Uri) => {
+      const fileUri = uri ?? vscode.window.activeTextEditor?.document.uri;
+      if (fileUri) provider?.addToChat(vscode.workspace.asRelativePath(fileUri));
+    }),
+
+    vscode.commands.registerCommand("opencode.addSelectionToChat", () => {
+      const editor = vscode.window.activeTextEditor;
+      if (editor) provider?.addToChat(selectionReference(editor));
+    }),
+
+    vscode.commands.registerCommand("opencode.restart", () => {
+      log("Restart command invoked");
+      serverManager?.dispose();
+      provider?.setLoading();
+      void startServer(context);
+    }),
+
     vscode.commands.registerCommand("opencode.toggleChatView", async () => {
-      if (!provider.isViewVisible) {
+      if (!provider?.isViewVisible) {
         await vscode.commands.executeCommand("opencode.chatView.focus");
         return;
       }
 
-      // Use cached sidebar type, default to auxiliary (secondary sidebar)
-      const tryFirst = provider.sidebarType ?? "auxiliary";
-      await vscode.commands.executeCommand(SIDEBAR_CMDS[tryFirst]);
+      const first = provider.sidebarType ?? "auxiliary";
+      await vscode.commands.executeCommand(SIDEBAR_CMDS[first]);
 
       if (!provider.isViewVisible) {
-        provider.sidebarType = tryFirst;
-        context.globalState.update("opencode.sidebarType", tryFirst);
+        provider.sidebarType = first;
+        context.globalState.update("opencode.sidebarType", first);
         return;
       }
 
-      // Wrong sidebar — undo and try the other
-      await vscode.commands.executeCommand(SIDEBAR_CMDS[tryFirst]);
-      const other = tryFirst === "auxiliary" ? "primary" : "auxiliary";
+      await vscode.commands.executeCommand(SIDEBAR_CMDS[first]);
+      const other = first === "auxiliary" ? "primary" : "auxiliary";
       await vscode.commands.executeCommand(SIDEBAR_CMDS[other]);
       provider.sidebarType = other;
       context.globalState.update("opencode.sidebarType", other);
     }),
-  );
 
-  // Register the restart command to kill the server and start fresh
-  context.subscriptions.push(
-    vscode.commands.registerCommand("opencode.restart", () => {
-      const restartConfig = vscode.workspace.getConfiguration("opencode");
-      const restartUserPort = restartConfig.get<number>("port", 0);
-      const restartPort =
-        restartUserPort > 0
-          ? restartUserPort
-          : (context.globalState.get<number>("opencode.serverPort") ?? port);
-      const restartProxyPort =
-        context.globalState.get<number>("opencode.proxyPort") ?? proxyPort;
-      const restartExposeToNetwork = restartConfig.get<boolean>(
-        "exposeToNetwork",
-        false,
-      );
-
-      serverManager?.dispose();
-      provider.setLoading();
-      serverManager = new ServerManager();
-      serverManager.start(
-        provider,
-        context,
-        restartPort,
-        restartProxyPort,
-        restartExposeToNetwork,
-      );
-    }),
-  );
-
-  // Prompt the user to restart when relevant settings change
-  context.subscriptions.push(
     vscode.workspace.onDidChangeConfiguration((e) => {
-      if (
-        e.affectsConfiguration("opencode.port") ||
-        e.affectsConfiguration("opencode.exposeToNetwork")
-      ) {
-        vscode.window
-          .showInformationMessage(
-            "opencode settings changed. Restart to apply?",
-            "Restart",
-          )
-          .then((choice) => {
-            if (choice === "Restart") {
-              vscode.commands.executeCommand("opencode.restart");
-            }
-          });
+      if (!e.affectsConfiguration("opencode.port") && !e.affectsConfiguration("opencode.exposeToNetwork")) {
+        return;
       }
+
+      log("OpenCode configuration changed");
+      vscode.window
+        .showInformationMessage("opencode settings changed. Restart to apply?", "Restart")
+        .then((choice) => {
+          if (choice === "Restart") void vscode.commands.executeCommand("opencode.restart");
+        });
     }),
   );
 }
 
-export function deactivate() {
+export function activate(context: vscode.ExtensionContext): void {
+  log("=== activate() called ===");
+  log(`Platform: ${process.platform}, VS Code: ${vscode.version}`);
+
+  provider = new OpencodeViewProvider();
+  provider.sidebarType = context.globalState.get<"primary" | "auxiliary">("opencode.sidebarType") ?? null;
+
+  context.subscriptions.push(
+    vscode.window.registerWebviewViewProvider("opencode.chatView", provider, {
+      webviewOptions: { retainContextWhenHidden: true },
+    }),
+    vscode.workspace.onDidChangeWorkspaceFolders(() => void startServer(context)),
+  );
+
+  registerCommands(context);
+  void startServer(context);
+
+  log("=== activate() complete ===");
+}
+
+export function deactivate(): void {
+  log("=== deactivate() called ===");
   serverManager?.dispose();
   serverManager = undefined;
 }

--- a/src/proxy/WebviewProxy.ts
+++ b/src/proxy/WebviewProxy.ts
@@ -8,7 +8,7 @@ import * as net from "net";
 // cross-origin limitations: keyboard shortcuts (copy/paste/cut),
 // clipboard access, and audio playback (Web Audio API fallback).
 
-const WEBVIEW_SCRIPT = /*html*/ `
+const WEBVIEW_SCRIPT = /*html*/ String.raw`
 <script>
   (function () {
     // ── Web Audio API fallback for VS Code webview autoplay restrictions ──
@@ -59,6 +59,95 @@ const WEBVIEW_SCRIPT = /*html*/ `
       for (var i = 0; i < bin.length; i++) buf[i] = bin.charCodeAt(i);
       return buf.buffer;
     }
+
+    function decodeBase64Url(value) {
+      if (!value) return null;
+      var base64 = value.replace(/-/g, "+").replace(/_/g, "/");
+      while (base64.length % 4) base64 += "=";
+
+      try {
+        var bin = atob(base64);
+        var bytes = new Uint8Array(bin.length);
+        for (var i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+        return new TextDecoder("utf-8").decode(bytes);
+      } catch (e) {
+        return null;
+      }
+    }
+
+    function currentDirectoryFromPath() {
+      var slug = location.pathname.replace(/^\/+/, "").split("/")[0];
+      if (!slug) return null;
+
+      var dir = decodeBase64Url(slug);
+      if (!dir) return null;
+
+      if (!/^[A-Za-z]:[\\/]/.test(dir) && !dir.startsWith("/") && !dir.startsWith("\\\\")) {
+        return null;
+      }
+
+      return dir;
+    }
+
+    function normalizeWindowsPath(value) {
+      if (!value) return value;
+      if (/^[A-Za-z]:[\\/]/.test(value) || value.indexOf("\\\\") === 0) {
+        return value.replace(/\//g, "\\");
+      }
+      return value;
+    }
+
+    function seedDeepLink() {
+      var defaultServerUrl = __OPENCODE_DEFAULT_SERVER_URL__;
+      if (defaultServerUrl) {
+        try {
+          var directUrl = defaultServerUrl.replace(/\/+$/, "");
+          var proxyUrl = location.origin.replace(/\/+$/, "");
+          localStorage.setItem("opencode.settings.dat:defaultServerUrl", defaultServerUrl);
+
+          var serverKey = "opencode.global.dat:server";
+          var state = JSON.parse(localStorage.getItem(serverKey) || "{}");
+          var list = Array.isArray(state.list) ? state.list : [];
+          var shouldDropServer = function (url) {
+            if (!url) return false;
+            var value = url.replace(/\/+$/, "");
+            if (value === directUrl) return false;
+            if (value === proxyUrl) return true;
+            try {
+              var parsed = new URL(value);
+              return parsed.hostname === "localhost" || parsed.hostname === "127.0.0.1";
+            } catch (e) {
+              return false;
+            }
+          };
+          list = list.filter(function (server) {
+            var url = typeof server === "string" ? server : server && server.http && server.http.url;
+            return !shouldDropServer(url);
+          });
+          if (!list.some(function (server) {
+            var url = typeof server === "string" ? server : server && server.http && server.http.url;
+            return url && url.replace(/\/+$/, "") === directUrl;
+          })) {
+            list.unshift({ type: "http", http: { url: directUrl } });
+          }
+          state.list = list;
+          localStorage.setItem(serverKey, JSON.stringify(state));
+        } catch (e) {}
+      }
+
+      var dir = normalizeWindowsPath(currentDirectoryFromPath());
+      if (!dir) return;
+
+      var openProjectLink = "opencode://open-project?directory=" + encodeURIComponent(dir);
+      var newSessionLink = "opencode://new-session?directory=" + encodeURIComponent(dir);
+      window.__OPENCODE__ = window.__OPENCODE__ || {};
+      var pending = window.__OPENCODE__.deepLinks || [];
+      if (pending.indexOf(openProjectLink) === -1) pending.push(openProjectLink);
+      if (pending.indexOf(newSessionLink) === -1) pending.push(newSessionLink);
+      window.__OPENCODE__.deepLinks = pending;
+    }
+
+    seedDeepLink();
 
     function getAudioBuffer(src) {
       if (src.indexOf("data:") === 0) {
@@ -305,8 +394,55 @@ const WEBVIEW_SCRIPT = /*html*/ `
 export function startWebviewProxy(
   targetPort: number,
   proxyPort: number = 0,
+  defaultServerUrl?: string,
 ): Promise<{ server: http.Server; port: number }> {
   return new Promise((resolve, reject) => {
+    const webviewScript = WEBVIEW_SCRIPT.replace(
+      "__OPENCODE_DEFAULT_SERVER_URL__",
+      JSON.stringify(defaultServerUrl ?? ""),
+    );
+    const patchedServerUrl = JSON.stringify(defaultServerUrl ?? "");
+
+    const patchScriptBody = (body: string) => {
+      if (!defaultServerUrl) return body;
+      return body.replace(
+        /location\.hostname\.includes\("opencode\.ai"\)\?"http:\/\/localhost:\d+":location\.origin/g,
+        patchedServerUrl,
+      );
+    };
+
+    const sendBuffered = (
+      res: http.ServerResponse,
+      proxyRes: http.IncomingMessage,
+      body: string,
+      removeCsp = false,
+    ) => {
+      const headers: http.OutgoingHttpHeaders = { ...proxyRes.headers };
+      headers["content-length"] = Buffer.byteLength(body).toString();
+      delete headers["content-encoding"];
+
+      if (removeCsp) {
+        delete headers["content-security-policy"];
+        delete headers["content-security-policy-report-only"];
+      }
+
+      res.writeHead(proxyRes.statusCode || 200, headers);
+      res.end(body);
+    };
+
+    const bufferResponse = (
+      proxyRes: http.IncomingMessage,
+      res: http.ServerResponse,
+      transform: (body: string) => string,
+      removeCsp = false,
+    ) => {
+      let body = "";
+      proxyRes.on("data", (chunk: Buffer) => {
+        body += chunk.toString();
+      });
+      proxyRes.on("end", () => sendBuffered(res, proxyRes, transform(body), removeCsp));
+    };
+
     const server = http.createServer((req, res) => {
       // Strip accept-encoding so we get an uncompressed body to inject into
       const headers: Record<string, string | string[] | undefined> = {
@@ -324,29 +460,19 @@ export function startWebviewProxy(
           headers,
         },
         (proxyRes) => {
-          const ct = proxyRes.headers["content-type"] || "";
+          const ct = String(proxyRes.headers["content-type"] || "");
 
           if (ct.includes("text/html")) {
-            // Buffer the HTML so we can inject the webview script
-            let body = "";
-            proxyRes.on("data", (chunk: Buffer) => {
-              body += chunk.toString();
-            });
-            proxyRes.on("end", () => {
-              body = body.includes("</head>")
-                ? body.replace("</head>", WEBVIEW_SCRIPT + "</head>")
-                : body + WEBVIEW_SCRIPT;
-
-              const outHeaders = { ...proxyRes.headers };
-              outHeaders["content-length"] = Buffer.byteLength(body).toString();
-              delete outHeaders["content-encoding"];
-              // Remove upstream CSP so our injected script can run
-              delete outHeaders["content-security-policy"];
-              delete outHeaders["content-security-policy-report-only"];
-
-              res.writeHead(proxyRes.statusCode || 200, outHeaders);
-              res.end(body);
-            });
+            bufferResponse(
+              proxyRes,
+              res,
+              (body) => body.includes("</head>")
+                ? body.replace("</head>", webviewScript + "</head>")
+                : body + webviewScript,
+              true,
+            );
+          } else if (ct.includes("javascript")) {
+            bufferResponse(proxyRes, res, patchScriptBody);
           } else {
             // Non-HTML: pipe through untouched
             res.writeHead(proxyRes.statusCode || 200, proxyRes.headers);

--- a/src/server/ServerManager.ts
+++ b/src/server/ServerManager.ts
@@ -1,166 +1,186 @@
 import * as vscode from "vscode";
 import { ChildProcess, spawn } from "child_process";
 import * as http from "http";
-import { OpencodeViewProvider } from "../webview/OpencodeViewProvider";
+import { log, logError } from "../logger";
 import { startWebviewProxy } from "../proxy/WebviewProxy";
+import { OpencodeViewProvider } from "../webview/OpencodeViewProvider";
+
+type StartOptions = {
+  provider: OpencodeViewProvider;
+  context: vscode.ExtensionContext;
+  cwd: string;
+  port: number;
+  proxyPort: number;
+  exposeToNetwork: boolean;
+  fixedPort: boolean;
+};
 
 export class ServerManager {
   private serverProcess: ChildProcess | undefined;
   private proxyServer: http.Server | undefined;
 
-  async start(
-    provider: OpencodeViewProvider,
-    context: vscode.ExtensionContext,
-    port: number,
-    proxyPort: number,
-    exposeToNetwork: boolean = false,
-  ): Promise<void> {
-    const cwd = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+  async start(options: StartOptions): Promise<void> {
+    const serverUrl = `http://localhost:${options.port}`;
+    log(`ServerManager.start: cwd="${options.cwd}"`);
 
-    if (!cwd) {
-      provider.setError("No workspace folder open.", false);
+    if (await this.isServerAlive(serverUrl)) {
+      log(`Using OpenCode server: ${serverUrl}`);
+      await this.openInWebview(options, serverUrl);
       return;
     }
 
-    // Persist the port so we can reuse it next time (preserves iframe localStorage)
-    context.globalState.update("opencode.serverPort", port);
-    context.globalState.update("opencode.proxyPort", proxyPort);
-
-    // Helper: start the keyboard proxy and hand the proxied URL to the provider.
-    // If another VS Code window already owns the proxy on the stored port we
-    // reuse it instead of spinning up a second proxy (which would land on a
-    // different port → different origin → lost localStorage preferences).
-    const serveViaProxy = async (serverUrl: string) => {
-      try {
-        const parsed = new URL(serverUrl);
-        const realPort = parseInt(parsed.port, 10);
-
-        // Check whether the proxy from another window is still alive.
-        if (
-          proxyPort > 0 &&
-          (await this.isServerAlive(`http://localhost:${proxyPort}`))
-        ) {
-          // Proxy already running — just reuse it (no new server to track).
-          parsed.port = proxyPort.toString();
-          parsed.pathname = `/${Buffer.from(cwd).toString("base64url")}`;
-          provider.setServerUrl(parsed.toString());
-          return;
-        }
-
-        const result = await startWebviewProxy(realPort, proxyPort);
-        this.proxyServer = result.server;
-
-        if (result.port !== proxyPort) {
-          context.globalState.update("opencode.proxyPort", result.port);
-        }
-
-        parsed.port = result.port.toString();
-        parsed.pathname = `/${Buffer.from(cwd).toString("base64url")}`;
-        provider.setServerUrl(parsed.toString());
-      } catch {
-        // Fallback: serve without proxy
-        try {
-          const u = new URL(serverUrl);
-          u.pathname = `/${Buffer.from(cwd).toString("base64url")}`;
-          provider.setServerUrl(u.toString());
-        } catch {
-          provider.setServerUrl(serverUrl);
-        }
-      }
-    };
-
-    // Check if a server from the previous session is still running on this port.
-    // If so, just reuse it instead of spawning a new one.
-    const existingUrl = `http://localhost:${port}`;
-    if (await this.isServerAlive(existingUrl)) {
-      await serveViaProxy(existingUrl);
-      return;
-    }
-
-    try {
-      const args = ["serve", "--port", port.toString()];
-      if (exposeToNetwork) {
-        args.push("--mdns");
-      }
-
-      this.serverProcess = spawn("opencode", args, {
-        cwd,
-        stdio: "pipe",
-        env: {
-          ...process.env,
-          OPENCODE_CALLER: "vscode",
-        },
-      });
-
-      let resolved = false;
-
-      const onUrl = (url: string) => {
-        if (resolved) return;
-        resolved = true;
-        serveViaProxy(url);
-      };
-
-      // Parse stdout/stderr for the server URL
-      const handleOutput = (data: Buffer) => {
-        const output = data.toString();
-        const match = output.match(/https?:\/\/[^\s]+/);
-        if (match) onUrl(match[0]);
-      };
-
-      this.serverProcess.stdout?.on("data", handleOutput);
-      this.serverProcess.stderr?.on("data", handleOutput);
-
-      this.serverProcess.on("error", (err) => {
-        if (resolved) return;
-        resolved = true;
-        if ((err as NodeJS.ErrnoException).code === "ENOENT") {
-          provider.setError("Could not find the <code>opencode</code> CLI.");
-        } else {
-          provider.setError(`Failed to start server: ${err.message}`);
-        }
-      });
-
-      this.serverProcess.on("exit", (code) => {
-        if (code !== null && code !== 0) {
-          if (!resolved) {
-            resolved = true;
-            provider.setError(
-              `OpenCode server exited with code ${code}. Check that your opencode installation is working.`,
-            );
-          }
-        }
-      });
-
-      // Fallback: if we don't see a URL in stdout after 5s, just try the expected URL
-      setTimeout(() => {
-        onUrl(`http://localhost:${port}`);
-      }, 5000);
-    } catch {
-      provider.setError("Failed to start the OpenCode server.");
-    }
+    await this.spawnServer(options, serverUrl);
   }
 
   dispose(): void {
+    log("ServerManager.dispose()");
+
     if (this.proxyServer) {
       this.proxyServer.close();
       this.proxyServer = undefined;
     }
+
     if (this.serverProcess) {
+      log(`Killing OpenCode process (PID=${this.serverProcess.pid})`);
       this.serverProcess.kill();
       this.serverProcess = undefined;
     }
   }
 
-  // Quick health check to see if a server from a previous session is still alive.
-  private async isServerAlive(url: string): Promise<boolean> {
+  private async spawnServer(options: StartOptions, expectedUrl: string): Promise<void> {
+    const args = ["serve", "--port", options.port.toString()];
+    if (options.exposeToNetwork) args.push("--mdns");
+
+    log(`Spawning: opencode ${args.join(" ")} (cwd=${options.cwd})`);
+
     try {
-      const controller = new AbortController();
-      const timeout = setTimeout(() => controller.abort(), 1000);
-      const res = await fetch(url, { signal: controller.signal });
-      clearTimeout(timeout);
+      this.serverProcess = spawn("opencode", args, {
+        cwd: options.cwd,
+        stdio: "pipe",
+        env: { ...process.env, OPENCODE_CALLER: "vscode" },
+      });
+    } catch (err) {
+      logError("Failed to spawn OpenCode", err);
+      options.provider.setError("Failed to start the OpenCode server.");
+      return;
+    }
+
+    log(`OpenCode process spawned, PID=${this.serverProcess.pid}`);
+    let resolved = false;
+
+    const resolveServer = async (url: string) => {
+      if (resolved) return;
+      resolved = true;
+
+      if (options.fixedPort && new URL(url).port !== String(options.port)) {
+        log(`Ignoring unexpected OpenCode port from child process: ${url}`);
+        if (await this.waitUntilAlive(expectedUrl)) {
+          this.serverProcess?.kill();
+          this.serverProcess = undefined;
+          await this.openInWebview(options, expectedUrl);
+          return;
+        }
+
+        this.serverProcess?.kill();
+        this.serverProcess = undefined;
+        options.provider.setError(`OpenCode did not start on the configured port ${options.port}.`, false);
+        return;
+      }
+
+      await this.openInWebview(options, options.fixedPort ? expectedUrl : url);
+    };
+
+    const handleOutput = (data: Buffer) => {
+      const match = data.toString().match(/https?:\/\/[^\s]+/);
+      if (match) void resolveServer(match[0]);
+    };
+
+    this.serverProcess.stdout?.on("data", handleOutput);
+    this.serverProcess.stderr?.on("data", handleOutput);
+
+    this.serverProcess.on("error", (err) => {
+      if (resolved) return;
+      resolved = true;
+      logError("OpenCode process error", err);
+
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+        options.provider.setError("Could not find the <code>opencode</code> CLI.");
+      } else {
+        options.provider.setError(`Failed to start server: ${err.message}`);
+      }
+    });
+
+    this.serverProcess.on("exit", async (code) => {
+      log(`OpenCode process exited with code ${code}`);
+      if (resolved || code === null || code === 0) return;
+
+      if (options.fixedPort && (await this.waitUntilAlive(expectedUrl))) {
+        resolved = true;
+        await this.openInWebview(options, expectedUrl);
+        return;
+      }
+
+      resolved = true;
+      options.provider.setError(
+        `OpenCode server exited with code ${code}. Check that your opencode installation is working.`,
+      );
+    });
+
+    setTimeout(() => void resolveServer(expectedUrl), 5000);
+  }
+
+  private async openInWebview(options: StartOptions, serverUrl: string): Promise<void> {
+    const workspacePath = `/${Buffer.from(options.cwd).toString("base64url")}`;
+    const directServerUrl = `http://localhost:${options.port}`;
+
+    try {
+      const parsed = new URL(serverUrl);
+      const targetPort = Number(parsed.port);
+
+      log("Starting VS Code webview bridge");
+      const proxy = await startWebviewProxy(targetPort, options.proxyPort, directServerUrl);
+      this.proxyServer = proxy.server;
+
+      if (proxy.port !== options.proxyPort) {
+        options.context.globalState.update("opencode.proxyPort", proxy.port);
+      }
+
+      parsed.port = proxy.port.toString();
+      parsed.pathname = workspacePath;
+      options.provider.setServerUrl(parsed.toString());
+    } catch (err) {
+      logError("VS Code webview bridge failed", err);
+      const fallback = new URL(serverUrl);
+      fallback.pathname = workspacePath;
+      options.provider.setServerUrl(fallback.toString());
+    }
+  }
+
+  private async waitUntilAlive(url: string): Promise<boolean> {
+    const deadline = Date.now() + 5000;
+    while (Date.now() < deadline) {
+      if (await this.isServerAlive(url, false)) return true;
+      await new Promise((resolve) => setTimeout(resolve, 250));
+    }
+    return false;
+  }
+
+  private async isServerAlive(url: string, logResult = true): Promise<boolean> {
+    const healthUrl = new URL("/global/health", url).toString();
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 5000);
+
+    try {
+      const res = await fetch(healthUrl, { signal: controller.signal });
+      if (logResult) log(`isServerAlive(${healthUrl}) = ${res.ok} (status=${res.status})`);
       return res.ok;
-    } catch {
+    } catch (err) {
+      if (logResult) {
+        log(`isServerAlive(${healthUrl}) = false (${err instanceof Error ? err.message : String(err)})`);
+      }
       return false;
+    } finally {
+      clearTimeout(timeout);
     }
   }
 }

--- a/src/webview/OpencodeViewProvider.ts
+++ b/src/webview/OpencodeViewProvider.ts
@@ -3,14 +3,13 @@ import * as fs from "fs";
 import * as path from "path";
 import * as os from "os";
 import { exec } from "child_process";
+import { log, logError } from "../logger";
 
 export class OpencodeViewProvider implements vscode.WebviewViewProvider {
   private _view?: vscode.WebviewView;
   private _serverUrl?: string;
   private _error?: { message: string; showInstallHint: boolean };
   private _sidebarType: "primary" | "auxiliary" | null = null;
-
-  constructor(private readonly _extensionUri: vscode.Uri) {}
 
   get isViewVisible(): boolean {
     return !!this._view?.visible;
@@ -25,13 +24,13 @@ export class OpencodeViewProvider implements vscode.WebviewViewProvider {
   }
 
   resolveWebviewView(webviewView: vscode.WebviewView) {
+    log("OpencodeViewProvider.resolveWebviewView()");
     this._view = webviewView;
 
     webviewView.webview.options = {
       enableScripts: true,
     };
 
-    // Handle paste requests relayed from the iframe through the webview script
     webviewView.webview.onDidReceiveMessage(async (message) => {
       if (message.type === "paste-request") {
         const text = await vscode.env.clipboard.readText();
@@ -49,6 +48,7 @@ export class OpencodeViewProvider implements vscode.WebviewViewProvider {
   }
 
   setServerUrl(url: string) {
+    log("OpencodeViewProvider.setServerUrl()");
     this._serverUrl = url;
     this._error = undefined;
     this._renderCurrentState();
@@ -61,12 +61,14 @@ export class OpencodeViewProvider implements vscode.WebviewViewProvider {
   }
 
   setError(message: string, showInstallHint = true) {
+    log(`OpencodeViewProvider.setError: "${message}" (installHint=${showInstallHint})`);
     this._error = { message, showInstallHint };
     this._serverUrl = undefined;
     this._renderCurrentState();
   }
 
   setLoading() {
+    log("OpencodeViewProvider.setLoading()");
     this._serverUrl = undefined;
     this._error = undefined;
     this._renderCurrentState();
@@ -164,12 +166,10 @@ export class OpencodeViewProvider implements vscode.WebviewViewProvider {
 
       exec(cmd, { timeout: 10_000 }, (err) => {
         void cleanup();
-        if (err) {
-          console.error("[OpenCode] System audio playback failed:", err.message);
-        }
+        if (err) logError("System audio playback failed", err);
       });
     } catch (err) {
-      console.error("[OpenCode] Failed to play audio data URI:", err);
+      logError("Failed to play audio data URI", err);
     }
   }
 }


### PR DESCRIPTION
Keep OpenCode keyed to the native Windows workspace path so existing project sessions are reused instead of creating slash-normalized projects. Reuse the configured server port while keeping the VS Code webview bridge internal for deep links and webview compatibility.