### PR TITLE
Support remote workspaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,9 @@ Unofficial extension that integrates the webview of opencode chat into your IDE.
 - **Seamless Clipboard Support**: Overcomes typical webview iframe limitations to provide full copy, cut, and paste functionality (including image pasting) within the chat.
 - **Persistent Sessions**: Saves your session, port, and user preferences across VS Code restarts.
 - **Local Network Access**: Enable the `opencode.exposeToNetwork` setting to access the same opencode instance from your mobile device or any other device on the same network at `http://opencode.local:<port>`.
+- **Remote Workspace Support**: Runs in the workspace extension host and routes the webview through VS Code's remote port forwarding, so SSH, Dev Containers, WSL, and Codespaces can load the chat from the remote machine.
 
-Note: requires opencode CLI to be installed. See https://opencode.ai/
+Note: requires the opencode CLI to be installed where the workspace runs. For Remote SSH, Dev Containers, WSL, and Codespaces, install `opencode` in the remote environment, not only on your local machine. See https://opencode.ai/
 
 ## Development
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "opencode-chat-unofficial",
   "displayName": "opencode chat",
-  "description": "opencode chat extension for the IDE",
+  "description": "opencode chat extension for local and remote VS Code workspaces",
   "repository": "https://github.com/kwickramasekara/opencode-chat",
   "publisher": "kwickramasekara",
   "version": "2.9.0",
@@ -13,6 +13,9 @@
   ],
   "icon": "icon.png",
   "activationEvents": [],
+  "extensionKind": [
+    "workspace"
+  ],
   "main": "./out/main.js",
   "contributes": {
     "commands": [

--- a/src/server/ServerManager.ts
+++ b/src/server/ServerManager.ts
@@ -26,6 +26,16 @@ export class ServerManager {
     context.globalState.update("opencode.serverPort", port);
     context.globalState.update("opencode.proxyPort", proxyPort);
 
+    const workspacePath = `/${Buffer.from(cwd).toString("base64url")}`;
+
+    const setWebviewServerUrl = async (url: URL) => {
+      url.pathname = workspacePath;
+      const externalUri = await vscode.env.asExternalUri(
+        vscode.Uri.parse(url.toString()),
+      );
+      provider.setServerUrl(externalUri.toString());
+    };
+
     // Helper: start the keyboard proxy and hand the proxied URL to the provider.
     // If another VS Code window already owns the proxy on the stored port we
     // reuse it instead of spinning up a second proxy (which would land on a
@@ -41,9 +51,9 @@ export class ServerManager {
           (await this.isServerAlive(`http://localhost:${proxyPort}`))
         ) {
           // Proxy already running — just reuse it (no new server to track).
-          parsed.port = proxyPort.toString();
-          parsed.pathname = `/${Buffer.from(cwd).toString("base64url")}`;
-          provider.setServerUrl(parsed.toString());
+          await setWebviewServerUrl(
+            new URL(`http://localhost:${proxyPort}`),
+          );
           return;
         }
 
@@ -54,15 +64,15 @@ export class ServerManager {
           context.globalState.update("opencode.proxyPort", result.port);
         }
 
-        parsed.port = result.port.toString();
-        parsed.pathname = `/${Buffer.from(cwd).toString("base64url")}`;
-        provider.setServerUrl(parsed.toString());
+        await setWebviewServerUrl(new URL(`http://localhost:${result.port}`));
       } catch {
         // Fallback: serve without proxy
         try {
           const u = new URL(serverUrl);
-          u.pathname = `/${Buffer.from(cwd).toString("base64url")}`;
-          provider.setServerUrl(u.toString());
+          if (u.hostname === "0.0.0.0" || u.hostname === "::") {
+            u.hostname = "localhost";
+          }
+          await setWebviewServerUrl(u);
         } catch {
           provider.setServerUrl(serverUrl);
         }

--- a/src/webview/OpencodeViewProvider.ts
+++ b/src/webview/OpencodeViewProvider.ts
@@ -102,10 +102,14 @@ export class OpencodeViewProvider implements vscode.WebviewViewProvider {
   }
 
   private _getIframeHtml(serverUrl: string): string {
-    return this._readTemplate("iframe.html").replaceAll(
-      "{{SERVER_URL}}",
-      serverUrl,
-    );
+    let serverOrigin = serverUrl;
+    try {
+      serverOrigin = new URL(serverUrl).origin;
+    } catch {}
+
+    return this._readTemplate("iframe.html")
+      .replaceAll("{{SERVER_URL}}", serverUrl)
+      .replaceAll("{{SERVER_ORIGIN}}", serverOrigin);
   }
 
   private _getErrorHtml(message: string, showInstallHint: boolean): string {

--- a/src/webview/templates/iframe.html
+++ b/src/webview/templates/iframe.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'none'; frame-src {{SERVER_URL}}; media-src {{SERVER_URL}}; style-src 'unsafe-inline'; script-src 'unsafe-inline';"
+      content="default-src 'none'; frame-src {{SERVER_ORIGIN}}; media-src {{SERVER_ORIGIN}} data: blob:; style-src 'unsafe-inline'; script-src 'unsafe-inline';"
     />
     <style>
       body {


### PR DESCRIPTION
@kwickramasekara 

## Summary

Added support for vscode remote workspaces. Implemented routing webview localhost URLs through vscode's port forwarding.

Checked that it works and that classic local mode is not broken.