### PR TITLE
fix: prevent webview freeze when clicking external links in chat

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -33,6 +33,7 @@ export function activate(context: vscode.ExtensionContext) {
 
   // Register the webview panel provider
   const provider = new OpencodeViewProvider(context.extensionUri);
+  provider.setDevMode(context.extensionMode === vscode.ExtensionMode.Development);
   context.subscriptions.push(
     vscode.window.registerWebviewViewProvider("opencode.chatView", provider, {
       webviewOptions: { retainContextWhenHidden: true },

--- a/src/proxy/WebviewProxy.ts
+++ b/src/proxy/WebviewProxy.ts
@@ -298,6 +298,33 @@ const WEBVIEW_SCRIPT = /*html*/ `
         }
       }
     });
+
+    // ── Intercept external link clicks and relay to extension host ──
+    document.addEventListener("click", function (e) {
+      var anchor = e.target.closest("a");
+      if (!anchor) return;
+
+      var href = anchor.getAttribute("href");
+      if (!href) return;
+
+      // Only intercept external HTTP(S) URLs that leave the current origin
+      var isExternal = false;
+      try {
+        var url = new URL(href, window.location.href);
+        if (
+          (url.protocol === "http:" || url.protocol === "https:") &&
+          url.origin !== window.location.origin
+        ) {
+          isExternal = true;
+        }
+      } catch (err) {}
+
+      if (isExternal) {
+        e.preventDefault();
+        e.stopPropagation();
+        window.parent.postMessage({ type: "open-external", url: href }, "*");
+      }
+    }, true);
   })();
 </script>
 `;

--- a/src/webview/OpencodeViewProvider.ts
+++ b/src/webview/OpencodeViewProvider.ts
@@ -48,6 +48,9 @@ export class OpencodeViewProvider implements vscode.WebviewViewProvider {
       if (message.type === "play-audio" && typeof message.src === "string") {
         void this._playAudioDataUri(message.src);
       }
+      if (message.type === "open-external" && typeof message.url === "string") {
+        vscode.env.openExternal(vscode.Uri.parse(message.url));
+      }
     });
 
     this._renderCurrentState();

--- a/src/webview/OpencodeViewProvider.ts
+++ b/src/webview/OpencodeViewProvider.ts
@@ -9,8 +9,13 @@ export class OpencodeViewProvider implements vscode.WebviewViewProvider {
   private _serverUrl?: string;
   private _error?: { message: string; showInstallHint: boolean };
   private _sidebarType: "primary" | "auxiliary" | null = null;
+  private _isDevMode = false;
 
   constructor(private readonly _extensionUri: vscode.Uri) {}
+
+  setDevMode(enabled: boolean) {
+    this._isDevMode = enabled;
+  }
 
   get isViewVisible(): boolean {
     return !!this._view?.visible;
@@ -96,9 +101,16 @@ export class OpencodeViewProvider implements vscode.WebviewViewProvider {
     return fs.readFileSync(templatePath, "utf-8");
   }
 
+  private _processTemplate(name: string): string {
+    return this._readTemplate(name).replaceAll(
+      "{{DEV_MODE}}",
+      this._isDevMode ? "flex" : "none",
+    );
+  }
+
   private _setLoadingHtml() {
     if (!this._view) return;
-    this._view.webview.html = this._readTemplate("loading.html");
+    this._view.webview.html = this._processTemplate("loading.html");
   }
 
   private _getIframeHtml(serverUrl: string): string {
@@ -107,7 +119,7 @@ export class OpencodeViewProvider implements vscode.WebviewViewProvider {
       serverOrigin = new URL(serverUrl).origin;
     } catch {}
 
-    return this._readTemplate("iframe.html")
+    return this._processTemplate("iframe.html")
       .replaceAll("{{SERVER_URL}}", serverUrl)
       .replaceAll("{{SERVER_ORIGIN}}", serverOrigin);
   }
@@ -117,7 +129,7 @@ export class OpencodeViewProvider implements vscode.WebviewViewProvider {
       ? "<p>Make sure <code>opencode</code> is installed and available in your PATH.</p>"
       : "";
 
-    return this._readTemplate("error.html")
+    return this._processTemplate("error.html")
       .replaceAll("{{ERROR_MESSAGE}}", message)
       .replaceAll("{{INSTALL_HINT}}", installHint);
   }

--- a/src/webview/templates/error.html
+++ b/src/webview/templates/error.html
@@ -35,9 +35,25 @@
         padding: 2px 6px;
         border-radius: 3px;
       }
+      .dev-badge {
+        position: fixed;
+        bottom: 8px;
+        right: 8px;
+        background: #e74c3c;
+        color: white;
+        font-family: sans-serif;
+        font-size: 10px;
+        font-weight: bold;
+        padding: 2px 6px;
+        border-radius: 4px;
+        z-index: 9999;
+        pointer-events: none;
+        display: {{DEV_MODE}};
+      }
     </style>
   </head>
   <body>
+    <div class="dev-badge">DEV</div>
     <div class="container">
       <div class="icon">⚠</div>
       <p>{{ERROR_MESSAGE}}</p>

--- a/src/webview/templates/iframe.html
+++ b/src/webview/templates/iframe.html
@@ -21,9 +21,25 @@
         height: 100%;
         border: none;
       }
+      .dev-badge {
+        position: fixed;
+        bottom: 8px;
+        right: 8px;
+        background: #e74c3c;
+        color: white;
+        font-family: sans-serif;
+        font-size: 10px;
+        font-weight: bold;
+        padding: 2px 6px;
+        border-radius: 4px;
+        z-index: 9999;
+        pointer-events: none;
+        display: {{DEV_MODE}};
+      }
     </style>
   </head>
   <body>
+    <div class="dev-badge">DEV</div>
     <iframe
       src="{{SERVER_URL}}"
       allow="clipboard-read; clipboard-write; autoplay"

--- a/src/webview/templates/iframe.html
+++ b/src/webview/templates/iframe.html
@@ -50,13 +50,16 @@
         var vscode = acquireVsCodeApi();
         var iframe = document.querySelector("iframe");
 
-        // Relay copy-request from iframe to extension host
+        // Relay copy-request / play-audio / open-external from iframe to extension host
         window.addEventListener("message", function (e) {
           if (e.data && e.data.type === "copy-request") {
             vscode.postMessage({ type: "copy-request", text: e.data.text });
           }
           if (e.data && e.data.type === "play-audio") {
             vscode.postMessage({ type: "play-audio", src: e.data.src });
+          }
+          if (e.data && e.data.type === "open-external") {
+            vscode.postMessage({ type: "open-external", url: e.data.url });
           }
         });
 

--- a/src/webview/templates/iframe.html
+++ b/src/webview/templates/iframe.html
@@ -27,6 +27,7 @@
     <iframe
       src="{{SERVER_URL}}"
       allow="clipboard-read; clipboard-write; autoplay"
+      sandbox="allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox"
     ></iframe>
     <script>
       (function () {

--- a/src/webview/templates/loading.html
+++ b/src/webview/templates/loading.html
@@ -39,9 +39,25 @@
         margin: 0;
         opacity: 0.7;
       }
+      .dev-badge {
+        position: fixed;
+        bottom: 8px;
+        right: 8px;
+        background: #e74c3c;
+        color: white;
+        font-family: sans-serif;
+        font-size: 10px;
+        font-weight: bold;
+        padding: 2px 6px;
+        border-radius: 4px;
+        z-index: 9999;
+        pointer-events: none;
+        display: {{DEV_MODE}};
+      }
     </style>
   </head>
   <body>
+    <div class="dev-badge">DEV</div>
     <div class="container">
       <svg
         class="icon"


### PR DESCRIPTION
## 🐛 Bug Description

Clicking external links (e.g., PR URLs) inside the opencode chat webview iframe caused the VS Code webview to freeze and become completely blank. The only recovery was to restart VS Code.

## 📝 Fix Summary

- **6 files changed, +99 / -4**
- `src/proxy/WebviewProxy.ts`: Injected script to intercept external link clicks inside the iframe
- `src/webview/OpencodeViewProvider.ts`: Added `open-external` message handler using `vscode.env.openExternal()`
- `src/webview/templates/iframe.html`: Added `open-external` message relay + iframe sandbox attribute + DEV badge support
- `src/webview/templates/loading.html`, `error.html`: Added DEV badge for development mode identification
- `src/main.ts`: Pass `extensionMode` to provider to control DEV badge visibility

## 🔍 Root Cause

The opencode server runs inside an iframe within a VS Code webview. When a user clicked an external URL in the chat, the browser attempted to navigate either:
1. Inside the iframe (replacing the chat UI), or
2. Through Electron's popup/new-window mechanism

Both paths violated VS Code's webview security model and caused the webview process to crash/blank.

## ✅ Fix Verification

- [x] Bug reproduced before fix
- [x] Bug no longer occurs after fix
- [x] Related functionality still works
- [x] Regression testing completed

**Verification steps:**
1. Launch Extension Development Host (`F5`)
2. Open opencode chat sidebar — confirm "DEV" badge appears
3. Chat with opencode and click an external link in the response
4. **Before fix:** Webview goes blank, requires restart
5. **After fix:** Link opens in OS default browser, chat UI remains intact

## 🔗 Related Issues

None

## 📋 Checklist

- [x] Self-reviewed the code
- [ ] Breaking changes documented (if any)
- [ ] Automated tests added or updated as appropriate
- [x] UI changes reviewed; screenshots added if useful
- [ ] Follow-up test coverage considered

## 📌 Notes

- This repository does not have an automated test infrastructure, so adding unit tests is out of scope.
- The DEV badge only appears when `ExtensionMode === Development`, so end users never see it.
